### PR TITLE
implement credentials module for #2

### DIFF
--- a/virl/api/api.py
+++ b/virl/api/api.py
@@ -1,22 +1,16 @@
 import requests
 import os
-
+from .credentials import get_credentials
 # TODO implement common credentials module
 # TODO implement basic models for the objects (swagger-gen)
-# TODO catch errors at VIRLServer().get() and VIRLServer().post() 
+# TODO catch errors at VIRLServer().get() and VIRLServer().post()
 
 class VIRLServer(object):
 
     def __init__(self, host=None, user=None, passwd=None, port=19399):
-        if not host:
-            host = os.getenv('VIRL_HOST')
-        if not user:
-            user = os.getenv('VIRL_USERNAME', 'guest')
-        if not passwd:
-            passwd = os.getenv('VIRL_PASSWORD', 'guest')
-        self._host = host
-        self._user = user
-        self._passwd = passwd
+
+        self._host, self._user, self._passwd = get_credentials()
+        
         self._port = port
         self.base_api = "http://{}:{}".format(self.host, self._port)
 

--- a/virl/api/credentials.py
+++ b/virl/api/credentials.py
@@ -1,0 +1,103 @@
+"""
+Collection of utility classes to make getting credentials and configuration easier.
+"""
+import getpass
+import os
+import sys
+import inspect
+
+
+def _get_from_user(prompt):
+    """
+    Get the input from the user through interactive prompt.
+    Use raw_input or input based on the Python version.
+    """
+    try:
+        resp = raw_input(prompt)
+    except NameError:
+        resp = input(prompt)
+    return resp
+
+
+def _get_password(prompt):
+    """
+    Get the password from the user through interactive prompt.
+    Using this will ensure that the password is not displayed as
+    it is typed.
+    """
+    return getpass.getpass(prompt)
+
+def _get_from_file(virlrc, prop_name):
+    if os.path.isfile(virlrc):
+        with open(virlrc) as fh:
+            config = fh.readlines()
+
+        for line in config:
+            if line.startswith(prop_name):
+                prop = line.split('=')[1].strip()
+                return prop
+
+
+def get_prop(prop_name):
+    """
+    Gets a variable using the following order
+    Check environment variables
+    Check for .virlrc in local directory
+    Check ~/.virlrc
+    Prompt user
+    """
+
+    # try environment first
+    prop = os.getenv(prop_name, None)
+    if prop:
+        return prop
+
+    # check for .virlrc in current directory
+    cwd = os.getcwd()
+    virlrc = os.path.join(cwd, ".virlrc")
+    prop = _get_from_file(virlrc, prop_name)
+
+    if prop:
+        return prop
+
+    #check for .virlrc in home directory
+    path = os.path.expanduser("~")
+    virlrc = os.path.join(path, ".virlrc")
+    prop = _get_from_file(virlrc, prop_name)
+
+    return prop or None
+
+
+def get_credentials(rcfile='~/.virlrc'):
+    """
+    Used to get the VIRL credentials
+
+    The login credentials are taken in the following order
+
+    Check environment variables
+    Check for .virlrc in current directory
+    Check ~/.virlrc
+    Prompt user
+
+    """
+    # initialize vars
+    host = None
+    username = None
+    password = None
+
+    host = get_prop('VIRL_HOST')
+    username = get_prop('VIRL_USERNAME')
+    password = get_prop('VIRL_PASSWORD')
+    if not host:
+        host = _get_from_user('Please enter the IP / hostname of your virl server: ')
+
+    if not username:
+        username = _get_from_user("Please enter your VIRL username: ")
+
+    if not password:
+        password = _get_password("Please enter your password: ")
+
+    if not all([host, username, password]):
+        sys.exit("Unable to determine VIRL credentials, please see docs for configuring")
+    else:
+        return (host, username, password)

--- a/virl/cli/main.py
+++ b/virl/cli/main.py
@@ -31,11 +31,4 @@ virl.add_command(generate)
 
 
 if __name__ == '__main__':
-    simengine_host = os.getenv("VIRL_HOST")
-    virl_user = os.getenv("VIRL_USER")
-    virl_password = os.getenv("VIRL_PASSWORD")
-
-    if not all([simengine_host, virl_user, virl_password]):
-        simengine_host = raw_input("Enter VIRL hostname/IP: ")
-
     cli()


### PR DESCRIPTION
This will have some breaking changes, we will no longer assume the user/pass of guest/guest, you will need to either set in your environment, or a .virlrc in either your home directory or current working directory. I've dropped credentials.py in favor of a consistent rc format

Sample environment 
```
export VIRL_HOST=1.1.1.1
export VIRL_USERNAME=guest
export VIRL_PASSWORD=guest
```

Sample .virlrc
```
VIRL_HOST=1.1.1.1
VIRL_USERNAME=guest
VIRL_PASSWORD=guest
```
