### PR TITLE
Add ability to import existing simulations that were launched by other users or from other interfaces

### DIFF
--- a/virl/api/api.py
+++ b/virl/api/api.py
@@ -1,22 +1,16 @@
 import requests
 import os
-
+from .credentials import get_credentials
 # TODO implement common credentials module
 # TODO implement basic models for the objects (swagger-gen)
-# TODO catch errors at VIRLServer().get() and VIRLServer().post() 
+# TODO catch errors at VIRLServer().get() and VIRLServer().post()
 
 class VIRLServer(object):
 
     def __init__(self, host=None, user=None, passwd=None, port=19399):
-        if not host:
-            host = os.getenv('VIRL_HOST')
-        if not user:
-            user = os.getenv('VIRL_USERNAME', 'guest')
-        if not passwd:
-            passwd = os.getenv('VIRL_PASSWORD', 'guest')
-        self._host = host
-        self._user = user
-        self._passwd = passwd
+
+        self._host, self._user, self._passwd = get_credentials()
+        
         self._port = port
         self.base_api = "http://{}:{}".format(self.host, self._port)
 

--- a/virl/api/credentials.py
+++ b/virl/api/credentials.py
@@ -1,0 +1,103 @@
+"""
+Collection of utility classes to make getting credentials and configuration easier.
+"""
+import getpass
+import os
+import sys
+import inspect
+
+
+def _get_from_user(prompt):
+    """
+    Get the input from the user through interactive prompt.
+    Use raw_input or input based on the Python version.
+    """
+    try:
+        resp = raw_input(prompt)
+    except NameError:
+        resp = input(prompt)
+    return resp
+
+
+def _get_password(prompt):
+    """
+    Get the password from the user through interactive prompt.
+    Using this will ensure that the password is not displayed as
+    it is typed.
+    """
+    return getpass.getpass(prompt)
+
+def _get_from_file(virlrc, prop_name):
+    if os.path.isfile(virlrc):
+        with open(virlrc) as fh:
+            config = fh.readlines()
+
+        for line in config:
+            if line.startswith(prop_name):
+                prop = line.split('=')[1].strip()
+                return prop
+
+
+def get_prop(prop_name):
+    """
+    Gets a variable using the following order
+    Check environment variables
+    Check for .virlrc in local directory
+    Check ~/.virlrc
+    Prompt user
+    """
+
+    # try environment first
+    prop = os.getenv(prop_name, None)
+    if prop:
+        return prop
+
+    # check for .virlrc in current directory
+    cwd = os.getcwd()
+    virlrc = os.path.join(cwd, ".virlrc")
+    prop = _get_from_file(virlrc, prop_name)
+
+    if prop:
+        return prop
+
+    #check for .virlrc in home directory
+    path = os.path.expanduser("~")
+    virlrc = os.path.join(path, ".virlrc")
+    prop = _get_from_file(virlrc, prop_name)
+
+    return prop or None
+
+
+def get_credentials(rcfile='~/.virlrc'):
+    """
+    Used to get the VIRL credentials
+
+    The login credentials are taken in the following order
+
+    Check environment variables
+    Check for .virlrc in current directory
+    Check ~/.virlrc
+    Prompt user
+
+    """
+    # initialize vars
+    host = None
+    username = None
+    password = None
+
+    host = get_prop('VIRL_HOST')
+    username = get_prop('VIRL_USERNAME')
+    password = get_prop('VIRL_PASSWORD')
+    if not host:
+        host = _get_from_user('Please enter the IP / hostname of your virl server: ')
+
+    if not username:
+        username = _get_from_user("Please enter your VIRL username: ")
+
+    if not password:
+        password = _get_password("Please enter your password: ")
+
+    if not all([host, username, password]):
+        sys.exit("Unable to determine VIRL credentials, please see docs for configuring")
+    else:
+        return (host, username, password)

--- a/virl/cli/main.py
+++ b/virl/cli/main.py
@@ -7,6 +7,7 @@ from .console.commands import console
 from .nodes.commands import nodes
 from .logs.commands import logs
 from .up.commands import up
+from .use.commands import use
 from .down.commands import down
 from .ls.commands import ls
 from .save.commands import save
@@ -24,6 +25,7 @@ virl.add_command(logs)
 virl.add_command(up)
 virl.add_command(down)
 virl.add_command(ls)
+virl.add_command(use)
 virl.add_command(save)
 virl.add_command(telnet)
 virl.add_command(ssh)

--- a/virl/cli/use/commands.py
+++ b/virl/cli/use/commands.py
@@ -1,0 +1,17 @@
+import click
+
+from virl.api import VIRLServer
+from virl.helpers import generate_sim_id, check_sim_running, store_sim_info
+import os, os.path
+
+
+@click.command()
+@click.argument('sim')
+def use(sim):
+    """
+    use virl simulation launched elsewhere
+    """
+    dirpath = os.getcwd()
+    foldername = os.path.basename(dirpath)
+    store_sim_info(sim, env='default') # 'topology-2lkx2'
+    click.secho('Now using VIRL simulation {}'.format(sim))

--- a/virl/helpers.py
+++ b/virl/helpers.py
@@ -3,6 +3,7 @@ import random
 import string
 import os
 import shutil
+import errno
 
 # Taken from https://stackoverflow.com/a/600612/119527
 def mkdir_p(path):


### PR DESCRIPTION
This PR Implements #6 

Occasionally you need to contextualize virl to a simulation that was launched in VMMaestro in some other location/project. This PR implements the ability to "use" that simulation. 

Here is a sample workflow:

There are no active simulations for your current project/directory
```
(virl) ➜  virlutils git:(import-env) virl ls
Running Simulations
╒══════════════╤══════════╤════════════╤═══════════╕
│ Simulation   │ Status   │ Launched   │ Expires   │
╞══════════════╪══════════╪════════════╪═══════════╡
╘══════════════╧══════════╧════════════╧═══════════╛
```

So you have no nodes...
```
(virl) ➜  virlutils git:(import-env) virl nodes
Environment default is not running
```

But there are some sims launched elsewhere
```
(virl) ➜  virlutils git:(import-env) virl ls --all
Running Simulations
╒════════════════════════════╤══════════╤════════════════════════════╤═══════════╕
│ Simulation                 │ Status   │ Launched                   │ Expires   │
╞════════════════════════════╪══════════╪════════════════════════════╪═══════════╡
│ ansible-vpn_default_7OeTMR │ ACTIVE   │ 2018-03-01T18:32:54.177365 │           │
╘════════════════════════════╧══════════╧════════════════════════════╧═══════════╛
```

Let's use one of them..
```
(virl) ➜  virlutils git:(import-env) virl use ansible-vpn_default_7OeTMR
Now using VIRL simulation ansible-vpn_default_7OeTMR
(virl) ➜  virlutils git:(import-env) ✗ virl nodes
Here is a list of all the running nodes
╒═══════════╤══════════╤═════════╤═════════════╤════════════╤══════════════════════╤════════════════════╕
│ Node      │ Type     │ State   │ Reachable   │ Protocol   │ Management Address   │ External Address   │
╞═══════════╪══════════╪═════════╪═════════════╪════════════╪══════════════════════╪════════════════════╡
│ host4     │ lxc      │ ACTIVE  │ REACHABLE   │ ssh        │ 10.94.241.244        │ N/A                │
├───────────┼──────────┼─────────┼─────────────┼────────────┼──────────────────────┼────────────────────┤
│ host0     │ lxc      │ ACTIVE  │ REACHABLE   │ ssh        │ 10.94.241.240        │ N/A                │
├───────────┼──────────┼─────────┼─────────────┼────────────┼──────────────────────┼────────────────────┤
│ host2     │ lxc      │ ACTIVE  │ REACHABLE   │ ssh        │ 10.94.241.242        │ N/A                │
├───────────┼──────────┼─────────┼─────────────┼────────────┼──────────────────────┼────────────────────┤
│ host3     │ lxc      │ ACTIVE  │ REACHABLE   │ ssh        │ 10.94.241.243        │ N/A                │
├───────────┼──────────┼─────────┼─────────────┼────────────┼──────────────────────┼────────────────────┤
│ internet  │ CSR1000v │ ACTIVE  │ REACHABLE   │ telnet     │ 10.94.241.229        │ N/A                │
├───────────┼──────────┼─────────┼─────────────┼────────────┼──────────────────────┼────────────────────┤
│ headend   │ CSR1000v │ ACTIVE  │ REACHABLE   │ telnet     │ 10.94.241.230        │ N/A                │
├───────────┼──────────┼─────────┼─────────────┼────────────┼──────────────────────┼────────────────────┤
│ ~mgmt-lxc │ mgmt-lxc │ ACTIVE  │ REACHABLE   │ ssh        │ 10.94.241.251        │ 10.94.241.252      │
├───────────┼──────────┼─────────┼─────────────┼────────────┼──────────────────────┼────────────────────┤
│ partner4  │ CSR1000v │ ACTIVE  │ REACHABLE   │ telnet     │ 10.94.241.234        │ N/A                │
├───────────┼──────────┼─────────┼─────────────┼────────────┼──────────────────────┼────────────────────┤
│ partner3  │ CSR1000v │ ACTIVE  │ REACHABLE   │ telnet     │ 10.94.241.233        │ N/A                │
├───────────┼──────────┼─────────┼─────────────┼────────────┼──────────────────────┼────────────────────┤
│ partner2  │ CSR1000v │ ACTIVE  │ REACHABLE   │ telnet     │ 10.94.241.232        │ N/A                │
├───────────┼──────────┼─────────┼─────────────┼────────────┼──────────────────────┼────────────────────┤
│ partner1  │ CSR1000v │ ACTIVE  │ REACHABLE   │ telnet     │ 10.94.241.231        │ N/A                │
├───────────┼──────────┼─────────┼─────────────┼────────────┼──────────────────────┼────────────────────┤
│ host1     │ lxc      │ ACTIVE  │ REACHABLE   │ ssh        │ 10.94.241.241        │ N/A                │
╘═══════════╧══════════╧═════════╧═════════════╧════════════╧══════════════════════╧════════════════════╛
```
