### PR TITLE
Fallback to `grid` option for broader terminal support

### DIFF
--- a/virl/cli/views/console/console_views.py
+++ b/virl/cli/views/console/console_views.py
@@ -14,4 +14,9 @@ def console_table(console_entries):
             tr.append(ip_port.split(":")[0])
             tr.append(ip_port.split(":")[1])
         table.append(tr)
-    click.echo(tabulate.tabulate(table, headers, tablefmt="fancy_grid"))
+    # wrap the output in this try/except block as some terminals
+    # may have problem with the 'fancy_grid'
+    try:
+        click.echo(tabulate.tabulate(table, headers, tablefmt="fancy_grid"))
+    except UnicodeEncodeError:
+        click.echo(tabulate.tabulate(table, headers, tablefmt="grid"))

--- a/virl/cli/views/logs/logs_views.py
+++ b/virl/cli/views/logs/logs_views.py
@@ -19,4 +19,9 @@ def log_table(log_entries):
         tr.append(click.style(level, fg=color))
         tr.append(log['message'])
         table.append(tr)
-    click.echo(tabulate.tabulate(table, headers, tablefmt="fancy_grid"))
+    # wrap the output in this try/except block as some terminals
+    # may have problem with the 'fancy_grid'
+    try:
+        click.echo(tabulate.tabulate(table, headers, tablefmt="fancy_grid"))
+    except UnicodeEncodeError:
+        click.echo(tabulate.tabulate(table, headers, tablefmt="grid"))

--- a/virl/cli/views/nodes/node_views.py
+++ b/virl/cli/views/nodes/node_views.py
@@ -38,5 +38,7 @@ def node_list_table(node_dict):
             tr.append(props.get("externalAddr", "N/A"))
 
             table.append(tr)
-
-    click.echo(tabulate.tabulate(table, headers, tablefmt="fancy_grid"))
+    try:
+        click.echo(tabulate.tabulate(table, headers, tablefmt="fancy_grid"))
+    except UnicodeEncodeError:
+        print(tabulate.tabulate(table, headers, tablefmt="fancy_grid"))

--- a/virl/cli/views/nodes/node_views.py
+++ b/virl/cli/views/nodes/node_views.py
@@ -38,7 +38,9 @@ def node_list_table(node_dict):
             tr.append(props.get("externalAddr", "N/A"))
 
             table.append(tr)
+    # wrap the output in this try/except block as some terminals
+    # may have problem with the 'fancy_grid'
     try:
         click.echo(tabulate.tabulate(table, headers, tablefmt="fancy_grid"))
     except UnicodeEncodeError:
-        print(tabulate.tabulate(table, headers, tablefmt="fancy_grid"))
+        click.echo(tabulate.tabulate(table, headers, tablefmt="grid"))

--- a/virl/cli/views/sims/sim_views.py
+++ b/virl/cli/views/sims/sim_views.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import click
 import tabulate
 
@@ -20,6 +21,8 @@ def sim_list_table(node_dict):
         tr.append(props['launched'])
         tr.append(props.get('expires', 'N/A'))
         table.append(tr)
+    # wrap the output in this try/except block as some terminals
+    # may have problem with the 'fancy_grid'
     try:
         click.echo(tabulate.tabulate(table, headers, tablefmt="fancy_grid"))
     except UnicodeEncodeError:

--- a/virl/cli/views/sims/sim_views.py
+++ b/virl/cli/views/sims/sim_views.py
@@ -1,6 +1,7 @@
 import click
 import tabulate
 
+
 def sim_list_table(node_dict):
     click.secho("Running Simulations", fg="green")
     table = list()
@@ -19,4 +20,7 @@ def sim_list_table(node_dict):
         tr.append(props['launched'])
         tr.append(props.get('expires', 'N/A'))
         table.append(tr)
-    click.echo(tabulate.tabulate(table, headers, tablefmt="fancy_grid"))
+    try:
+        click.echo(tabulate.tabulate(table, headers, tablefmt="fancy_grid"))
+    except UnicodeEncodeError:
+        click.echo(tabulate.tabulate(table, headers, tablefmt="grid"))


### PR DESCRIPTION
Some terminals can't encode the fancy_grid (closes #18) tabulate format, so we will fallback to grid.