### PR TITLE
Add command to retrieve simulation id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# virl stuff 
+.virl/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.virl/default/id
+++ b/.virl/default/id
@@ -1,1 +1,0 @@
-ansible-vpn-dyn_default_aHwJPe

--- a/tests/id.py
+++ b/tests/id.py
@@ -1,0 +1,17 @@
+from . import BaseTest
+from .mocks.api import MockVIRLServer
+from click.testing import CliRunner
+import requests_mock
+from virl.cli.main import virl
+
+
+class IdTest(BaseTest):
+
+    def test_virl_id_nosim(self):
+        with requests_mock.mock() as m:
+            # Mock the request to return what we expect from the API.
+            m.get('http://localhost:19399/simengine/rest/list',
+                  json=MockVIRLServer.list_simulations())
+            runner = CliRunner()
+            result = runner.invoke(virl, ["id"])
+            self.assertEqual("virlutils-id\n", result.output)

--- a/tests/mocks/api.py
+++ b/tests/mocks/api.py
@@ -252,6 +252,12 @@ class MockVIRLServer:
                     'expires': None,
                     'launched': '2017-12-08T18:48:34.174486',
                 },
+                'virlutils-id': {
+                    'status': 'ACTIVE',
+                    'expires': None,
+                    'launched': '2017-12-08T18:48:34.174486',
+                },
+
             }
         }
         return response

--- a/virl/cli/id/commands.py
+++ b/virl/cli/id/commands.py
@@ -1,0 +1,23 @@
+import os
+import click
+from virl.api import VIRLServer
+
+
+@click.command()
+def id():
+    """
+    gets sim id for local environment
+    """
+
+    server = VIRLServer()
+
+    sim_dict = server.list_simulations()
+    dirpath = os.getcwd()
+    foldername = os.path.basename(dirpath)
+    for k in list(sim_dict):
+        if not k.startswith(foldername):
+            sim_dict.pop(k)
+    # can only accurately determine sim id if there is
+    # only one sim running with our project name
+    if len(sim_dict) == 1:
+        click.echo(sim_dict.keys()[0])

--- a/virl/cli/id/commands.py
+++ b/virl/cli/id/commands.py
@@ -20,4 +20,4 @@ def id():
     # can only accurately determine sim id if there is
     # only one sim running with our project name
     if len(sim_dict) == 1:
-        click.echo(sim_dict.keys()[0])
+        click.echo(list(sim_dict)[0])

--- a/virl/cli/main.py
+++ b/virl/cli/main.py
@@ -17,6 +17,7 @@ from .search.commands import search
 from .swagger.commands import swagger
 from .uwm.commands import uwm
 from .viz.commands import viz
+from .id.commands import id
 
 
 @click.group()
@@ -42,6 +43,8 @@ virl.add_command(pull)
 virl.add_command(swagger)
 virl.add_command(uwm)
 virl.add_command(viz)
+virl.add_command(id)
+
 
 if __name__ == '__main__':
     virl()  # pragma: no cover


### PR DESCRIPTION
This is useful for situations where you need to quickly import an existing project for use

e.g. 

```
virl use $(virl id)
```