### PR TITLE
Add provisioner flag to block until all nodes are ready

### DIFF
--- a/virl/api/api.py
+++ b/virl/api/api.py
@@ -83,10 +83,25 @@ class VIRLServer(object):
         r = self.get(u)
         return r
 
-    # def get_nodes(self, simulation):
-    #     url = self.base_api + "/simengine/rest/nodes/{}".format(simulation)
-    #     r = requests.get(url, auth=(self.user, self.passwd))
-    #     return r.json()[simulation]
+    def get_node_summary(self, simulation):
+        url = self.base_api + "/simengine/rest/nodes/{}".format(simulation)
+        r = requests.get(url, auth=(self.user, self.passwd))
+        nodes = r.json()[simulation]
+        return nodes
+
+    def get_node_list(self, simulation):
+        """
+        returns a list of node,status tuples
+        """
+        nodes = self.get_node_summary(simulation)
+        return nodes.keys()
+
+    def check_node_reachable(self, simulation, node_name):
+        """
+        returns a list of node,status tuples
+        """
+        nodes = self.get_node_summary(simulation)
+        return nodes[node_name]['reachable']
 
     def export(self, simulation, ip=False):
         """

--- a/virl/cli/up/commands.py
+++ b/virl/cli/up/commands.py
@@ -10,15 +10,14 @@ import time
 @click.argument('repo', default='default')
 @click.option('-e', default='default', help="environment name", required=False)
 @click.option('-f', default='topology.virl', help='filename', required=False)
-@click.option('--provision', default=1, help=" \
+@click.option('--provision', default=False, show_default=True, help=" \
 Blocks execution until all nodes are reachable.", required=False)
-def up(repo=None, provision=1, **kwargs):
+def up(repo=None, provision=False, **kwargs):
     """
     start a virl simulation
     """
     fname = kwargs['f']
     env = kwargs['e']
-
     print(kwargs)
 
     if os.path.exists(fname):
@@ -60,8 +59,10 @@ def up(repo=None, provision=1, **kwargs):
 
             if provision:
                 nodes = server.get_node_list(sim_name)
-                click.secho("Waiting for nodes to come online....")
-                maxtime = time.time() + 60 * provision
+                msg = "Waiting {} minutes for nodes to come online...."
+                msg = msg.format(provision)
+                click.secho(msg)
+                maxtime = time.time() + 60 * int(provision)
                 with click.progressbar(nodes) as all_nodes:
                     for node in all_nodes:
                         node_online = False
@@ -72,6 +73,7 @@ def up(repo=None, provision=1, **kwargs):
                             time.sleep(20)
                             node_online = server.check_node_reachable(sim_name,
                                                                       node)
+            # remove this
             else:
                 print('provision flag not set')
 


### PR DESCRIPTION
This is the initial attempt at #38 

NOTE: there are no unittests for this, as the `virl up` command is a bit overloaded with arguments/options which make testing difficult.  