### PR TITLE
Update flat1_gateway tag to have even spacing

### DIFF
--- a/virl/cli/up/commands.py
+++ b/virl/cli/up/commands.py
@@ -38,7 +38,7 @@ def up(repo=None, provision=False, **kwargs):
             # <dirty hack>
             subs = {
                 "{{ gateway }}": server.get_gateway_for_network('flat'),
-                "{{ flat1_gateway}}": server.get_gateway_for_network('flat1'),
+                "{{ flat1_gateway }}": server.get_gateway_for_network('flat1'),
                 "{{ dns_server }}": server.get_dns_server_for_network('flat'),
             }
 


### PR DESCRIPTION
Documentation on main page shows that "{{ flat1_gateway }}" will get substituted. It doesn't. I found that this is because of the dirty hack section here. The string substitution for flat1_gateway is missing a space between the end of the variable and the first brace.

There are 4 different ways to fix this.
1: put the variable to be substituted in the topology file as `{{ flat1_gateway}}` ... this is not obvious without reading the code
2: update the docs on the main page to reflect this discrepancy
3: update the code as I did here
4: run the file through Jinja... If you're open to this I can work on a PR for doing it, but not sure how actively maintained this is